### PR TITLE
Only show AAL of earthquake on building calculator. Fix #28

### DIFF
--- a/app/assets/scripts/components/calculator-modal.js
+++ b/app/assets/scripts/components/calculator-modal.js
@@ -139,7 +139,7 @@ const Calculator = React.createClass({
     // force Costa Rica to display replacement as there is no retrofit data
     conversion = (activeCountry === 'CR') ? 'replacement' : conversion
 
-    const aal = aals.find(a => a.id === activeId)[`LS_${this.props.dataSelection.risk.getActive().value}_AAL`]
+    const aal = aals.find(a => a.id === activeId)['LS_EQ_AAL']
 
     const data = getBuildingData(activeId, conversion, sliderValue, this.props.unitCostOfConstruction)
     let ucc = this.props.unitCostOfConstruction || data.unitCostOfConstruction
@@ -160,7 +160,7 @@ const Calculator = React.createClass({
         <div className='modal__inner'>
           <header className='modal__header'>
             <div className='modal__headline'>
-              <h1 className='modal__title'>{t('Risk mitigation cost and benefit calculator')}</h1>
+              <h1 className='modal__title'>{t('Risk mitigation cost and benefit calculator - earthquake')}</h1>
               <button className='modal__button-dismiss' title='Close' onClick={this.hideModal}><span>Dismiss</span></button>
             </div>
           </header>

--- a/app/assets/scripts/utils/i18n.js
+++ b/app/assets/scripts/utils/i18n.js
@@ -102,7 +102,7 @@ export function t (string, replace = {}) {
       'No building data for this region': 'No building data for this region',
 
       // Calculator
-      'Risk mitigation cost and benefit calculator': 'Risk mitigation cost and benefit calculator',
+      'Risk mitigation cost and benefit calculator - earthquake': 'Risk mitigation cost and benefit calculator - earthquake',
       'Conversion Settings': 'Conversion Settings',
       'Country Selected': 'Country Selected',
       'Subregion Selected': 'Subregion Selected',
@@ -381,7 +381,7 @@ export function t (string, replace = {}) {
       'No building data for this region': 'No building data for this region',
 
       // Calculator
-      'Risk mitigation cost and benefit calculator': 'Calculador del costo y beneficio de la mitigación de riesgo',
+      'Risk mitigation cost and benefit calculator - earthquake': 'Calculador del costo y beneficio de la mitigación de riesgo - terremoto',
       'Conversion Settings': 'Configuraciones de conversión',
       'Country Selected': 'País seleccionado',
       'Subregion Selected': 'Subregión seleccionada',


### PR DESCRIPTION
With this PR, the overall reduction in AAL is always calculated based for the earthquake scenario. The header of the modal was updated to reflect that:

![image](https://user-images.githubusercontent.com/751330/37401457-79e1ec48-275e-11e8-870e-0cb6b5ae358c.png)
